### PR TITLE
Responsive fixes in UI header

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -36,7 +36,7 @@ const Header: React.FC = () => {
       <div className="logo">Logo</div>
       <div className="dropdown-container" ref={dropdownRef}>
 
-        <div className="dropdown" onClick={() => dispatch(selectMenu('home_base'))}>Homebase</div>
+        <div className="dropdown" onClick={() => dispatch(selectMenu('home_base'))}>Home</div>
 
         <div className="separator">|</div>
 

--- a/src/styles/_header.scss
+++ b/src/styles/_header.scss
@@ -91,7 +91,7 @@
 /* Responsive adjustments */
 @media (max-width: 768px) {
   .header {
-    flex-direction: column;
+    flex-direction: row;
     align-items: flex-start;
 
     .logo {
@@ -100,7 +100,7 @@
 
     .dropdown-container {
       width: 100%;
-      flex-direction: column;
+      flex-direction: row;
 
       .dropdown {
         width: 100%;


### PR DESCRIPTION
Responsive fixes in UI header. The header will stay horizontal and menu items will not be placed in a column on a smaller screen. Need to test it on a mobile device.